### PR TITLE
Adding support for configuration changes #1.

### DIFF
--- a/app/src/main/java/com/luisbarqueira/todocompose/MainActivity.kt
+++ b/app/src/main/java/com/luisbarqueira/todocompose/MainActivity.kt
@@ -24,7 +24,6 @@ class MainActivity : ComponentActivity() {
     private val sharedViewModel by viewModels<SharedViewModel>()
 
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -33,8 +32,8 @@ class MainActivity : ComponentActivity() {
                 SetupNavigation(
                     navController = navController,
                     sharedViewModel = sharedViewModel,
-                    action = sharedViewModel.action.value,
-                    changeAction = sharedViewModel::changeAction
+                    changeAction = sharedViewModel::changeAction,
+                    action = sharedViewModel.action.value
                 )
             }
         }

--- a/app/src/main/java/com/luisbarqueira/todocompose/navigation/Navigation.kt
+++ b/app/src/main/java/com/luisbarqueira/todocompose/navigation/Navigation.kt
@@ -20,15 +20,9 @@ import com.luisbarqueira.todocompose.util.toAction
 fun SetupNavigation(
     navController: NavHostController,
     sharedViewModel: SharedViewModel,
-    action: Action,
-    changeAction: (Action) -> Unit
+    changeAction: (Action) -> Unit,
+    action: Action
 ) {
-/*    val screen = remember(navController) {
-        Screens(navController = navController)
-    }*/
-
-    var myAction by rememberSaveable { mutableStateOf(Action.NO_ACTION) }
-
     Log.d("SetupNavigation", "Recomposition of SetupNavigation")
 
     NavHost(
@@ -40,7 +34,6 @@ fun SetupNavigation(
         // routes are represented as strings.
         // A named argument is provided inside routes in curly braces like this {argument}.
 
-        // FIXME: LaunchedEffect not working on configuration changes
         composable(
             route = "list/{action}", // LIST_SCREEN
             arguments = listOf(
@@ -49,19 +42,16 @@ fun SetupNavigation(
                     type = NavType.StringType
                 })
         ) { entry -> // Look up "action" in NavBackStackEntry's arguments
-            myAction = entry.arguments?.getString("action").toAction()
 
-            Log.d("SetupNavigation", "myAction = ${myAction.name}")
-            Log.d("SetupNavigation", "action = ${action.name}")
+            val actionArg = entry.arguments?.getString("action").toAction()
 
+            var myAction by rememberSaveable { mutableStateOf(Action.NO_ACTION) }
 
-            // whenever actionName changes the block of code inside is triggered
+            // whenever myAction changes the block of code inside is triggered
             LaunchedEffect(key1 = myAction) {
-                // sharedViewModel.action.value = action
-                if (action != myAction) {
-                    changeAction(myAction)
-                    Log.d("SetupNavigation", "myAction_afterchange = ${action.name}")
-                    myAction = action
+                if (actionArg != myAction) {
+                    myAction = actionArg
+                    changeAction(myAction)  // sharedViewModel.action.value = myAction
                 }
             }
 
@@ -74,11 +64,6 @@ fun SetupNavigation(
             )
         }
 
-
-/*        listComposable (
-            navigateToTaskScreen = screen.task
-        )*/
-
         composable(
             route = "task/{taskId}", // TASK_SCREEN
             arguments = listOf(
@@ -87,10 +72,8 @@ fun SetupNavigation(
                     type = NavType.IntType
                 })
         ) { entry -> // Look up "taskId" in NavBackStackEntry's arguments
-            val taskId = entry.arguments!!.getInt("taskId")
 
-            //FIXME: To eliminate this Log.d
-            // Log.d("SetupNavigation", "taskId = $taskId")
+            val taskId = entry.arguments!!.getInt("taskId")
 
             sharedViewModel.getSelectedTask(taskId = taskId)
 
@@ -114,11 +97,5 @@ fun SetupNavigation(
                 }
             )
         }
-
-
-/*        taskComposable(
-            navigateToListScreen = screen.list
-        )*/
-
     }
 }

--- a/app/src/main/java/com/luisbarqueira/todocompose/ui/screens/list/ListScreen.kt
+++ b/app/src/main/java/com/luisbarqueira/todocompose/ui/screens/list/ListScreen.kt
@@ -53,9 +53,6 @@ fun ListScreen(
     val searchTextState: String = sharedViewModel.searchTextState.value
 
 
-    // val action by sharedViewModel.action
-
-
     // sharedViewModel.handleDatabaseActions(action)
 
     val scaffoldState:ScaffoldState = rememberScaffoldState()


### PR DESCRIPTION
Solves the following issue #1 : when configuration changes then the launched effect will be triggered once again and it will cause to add another item in the database. We need somehow to create the logic not to trigger that "sharedViewModel.value = action" line of code when configuration change happens.

Replaced that block of code with this:
var myAction by rememberSaveable { mutableStateOf(Action.NO_ACTION) }

LaunchedEffect(key1 = myAction) {
if (action != myAction) {
myAction = action
sharedViewModel.action.value = myAction
}
}

That way our myAction variable will be passed as a key to the LaunchedEffect, which will NOT trigger "sharedViewModel.value = myAction" when configuration changes as before. We are using here rememberSaveable, which is basically the same as remember, with only one difference. It will persist or save the value not only on recomposition but on configuration change as well. I hope I've answer your question. If you have more, feel free to comment down below and I'll be happy to help you. :)